### PR TITLE
create a package config file to be placed in install/lib/pkgconfig/pa…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,3 +114,5 @@ write_basic_package_version_file(parafeedConfigVersion.cmake
   COMPATIBILITY AnyNewerVersion)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/parafeedConfigVersion.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/parafeed)
+# Generate the parafeed.pc file
+configure_file(parafeed.pc.in ${CMAKE_INSTALL_LIBDIR}/pkgconfig/parafeed.pc @ONLY)

--- a/parafeed.pc.in
+++ b/parafeed.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: parafeed
+Description: The parafeed library
+Version: @parafeed_VERSION@
+Libs: -L${libdir} -lparafeed
+Cflags: -I${includedir}


### PR DESCRIPTION
Created `parafeed.pc` for discovery with pacakge config post installation. Current discovery method is based on `-DCMAKE_PREFIX_PATH=install/lib/cmake/parafeed`. This will now allow discovery as follows

```
include(FindPkgConfig)
pkg_check_modules(parafeed REQUIRED IMPORTED_TARGET libparafeed)
```