### PR TITLE
Merging hotfix_helpdef: This fixes the seg fault on machines/containers with limited terminal capabilities

### DIFF
--- a/code/ParseCmdLine.cc
+++ b/code/ParseCmdLine.cc
@@ -243,7 +243,7 @@ int ParseCmdLine(int argc, char *argv[])
 	    if (S->NVals > 1)  defFile=S->Val[1];
 
 	    doload_and_register((char *)defFile.c_str());
-	    doinp((char *)"-a");
+	    //	    doinp((char *)"-a");
 	    // doload_and_register() reads the .def file into cl_SymbTab directly.
 	    // clLoadSymb() in this case isn't required.
 	    //
@@ -255,6 +255,7 @@ int ParseCmdLine(int argc, char *argv[])
 
 	    // Change interface to do*() functions (in
 	    // callbacks_awk.cc) to take const char*.  Someday.
+
 	    if (S->Val[0] == "defdbg") doinp((char *)("-a"));
 	  }
       }

--- a/code/callbacks.cc
+++ b/code/callbacks.cc
@@ -531,16 +531,17 @@ END{									\
 	    if (getline(ifs,line))
 	      {
 		stripwhitep(line);
-		if (line.size() > 0)
+		if ((line.size() > 0) && (line[0] != '#'))
 		  {
 		    std::string Name_str, Val_str;
 		    BreakStrp(line,Name_str,Val_str);
-		    // cerr << line << endl;
-		    // cerr << "Name:'" << Name_str << "' Val:'" << Val_str << "'" << endl;
+		    cerr << line << endl;
+		    //		     cerr << "Name:'" << Name_str << "' Val:'" << Val_str << "'" << endl;
 		    stripwhitep(Name_str);
 		    stripwhitep(Val_str);
-		    // cerr << "Name:'" << Name_str << "' Val:'" << Val_str << "'" << endl;
+		    //		     cerr << "Name:'" << Name_str << "' Val:'" << Val_str << "'" << endl;
 		    pos = NULL;
+
 		    if (Complement)
 		      {
 			pos=SearchVSymbFullMatch(Name_str.c_str(),cl_SymbTab);

--- a/code/callbacks.cc
+++ b/code/callbacks.cc
@@ -491,8 +491,6 @@ END{									\
     ------------------------------------------------------------------------*/
   int doload_and_register(char *f)
   {
-    // FILE *fd;
-    // char str[MAXBUF];
     int Complement=0;
 
     ifstream ifs;
@@ -504,36 +502,27 @@ END{									\
     if(f==NULL || strlen(f) == 0)
       {
 	strcpp = cl_ProgName; 
-	//	strcpy(str,cl_ProgName);
 #ifdef GNUREADLINE
 	//	str[strlen(cl_ProgName)-1]='\0';
 	strcpp=strcpp.substr(0,strlen(cl_ProgName)-1);
 #endif
-	//	strcat(str,".def");
 	strcpp.append(".def");
       }
     else 
-      //      strcpy(str,f);
       strcpp = f;
     
-    //    if (str[strlen(str)-1] == '!') 
     if (strcpp[strcpp.size()-1] == '!') 
       {Complement = 1; strcpp[strcpp.size()-1] = (char)NULL;}
 
-    //    cerr << "Loading from " << strcpp << "...not yet working" << endl;
     ifs.open(strcpp.c_str());
-    //    if ((fd = fopen(str,"r"))==NULL)
+
     if (!ifs.good())
       {
-	//    	fprintf(stderr,"###Error: Error in opening file \"%s\"\n",strcpp.c_str());
 	clThrowUp(std::string("Error in opening file \"")+strcpp+std::string("\""), "###Error", CL_FATAL);
-	//cerr << "###Error: Error in opening file \"" << strcpp << "\"" << endl;
 	return 2;
       }
-    else
+   else
       {
-	//	char *Name=NULL, *Val=NULL;
-	std::string Name_str, Val_str;
 	Symbol *pos;
 	
 	while(!ifs.eof())
@@ -541,20 +530,19 @@ END{									\
 	    string line;
 	    if (getline(ifs,line))
 	      {
-		// char *str_p=(char *)line.c_str();
-		// stripwhite(str_p);//str_p[strlen(str_p)-1]='\0';
 		stripwhitep(line);
-		//	char *str_p=(char *)line.c_str();
-		//if (strlen(str_p) > 0)
 		if (line.size() > 0)
 		  {
+		    std::string Name_str, Val_str;
 		    BreakStrp(line,Name_str,Val_str);
-		    //		    BreakStr(str_p,&Name,&Val);
-
+		    // cerr << line << endl;
+		    // cerr << "Name:'" << Name_str << "' Val:'" << Val_str << "'" << endl;
+		    stripwhitep(Name_str);
+		    stripwhitep(Val_str);
+		    // cerr << "Name:'" << Name_str << "' Val:'" << Val_str << "'" << endl;
 		    pos = NULL;
 		    if (Complement)
 		      {
-			//		      pos=SearchVSymb(Name,cl_SymbTab);
 			pos=SearchVSymbFullMatch(Name_str.c_str(),cl_SymbTab);
 			if ((pos == (Symbol *)NULL))
 			  pos=AddVar(Name_str.c_str(),&cl_SymbTab,&cl_TabTail);
@@ -563,17 +551,12 @@ END{									\
 		      }
 		    if (pos==NULL)
 		      {
-			// pos=AddVar(Name,&cl_SymbTab,&cl_TabTail);
-			// SetVar(Name,Val,cl_SymbTab,0,1,cl_do_doinp);
 			pos=AddVar(Name_str.c_str(),&cl_SymbTab,&cl_TabTail);
 			SetVar((char*)Name_str.c_str(),(char *)Val_str.c_str(),cl_SymbTab,0,1,cl_do_doinp);
 		      }
-		    // if (Name != NULL) {free(Name);Name=NULL;}
-		    // if (Val != NULL) {free(Val);Name=NULL;}
 		  }
 	      }
 	  }
-	//	fclose(fd);
       }
     cl_do_doinp=0;
     return 1;

--- a/code/callbacks.cc
+++ b/code/callbacks.cc
@@ -532,40 +532,44 @@ END{									\
       }
     else
       {
-	char *Name=NULL, *Val=NULL;
+	//	char *Name=NULL, *Val=NULL;
+	std::string Name_str, Val_str;
 	Symbol *pos;
 	
-	//	while(!feof(fd))
 	while(!ifs.eof())
 	  {
 	    string line;
-	    //	    for (i=0;i<MAXBUF;i++)str[i]='\0';
-	    //	    if (fgets(str,MAXBUF,fd)!=NULL)
 	    if (getline(ifs,line))
 	      {
-		char *str_p=(char *)line.c_str();
-		//		cerr << line << endl;
-		stripwhite(str_p);//str_p[strlen(str_p)-1]='\0';
-		if (strlen(str_p) > 0)
+		// char *str_p=(char *)line.c_str();
+		// stripwhite(str_p);//str_p[strlen(str_p)-1]='\0';
+		stripwhitep(line);
+		//	char *str_p=(char *)line.c_str();
+		//if (strlen(str_p) > 0)
+		if (line.size() > 0)
 		  {
-		    BreakStr(str_p,&Name,&Val);
+		    BreakStrp(line,Name_str,Val_str);
+		    //		    BreakStr(str_p,&Name,&Val);
+
 		    pos = NULL;
 		    if (Complement)
 		      {
 			//		      pos=SearchVSymb(Name,cl_SymbTab);
-			pos=SearchVSymbFullMatch(Name,cl_SymbTab);
+			pos=SearchVSymbFullMatch(Name_str.c_str(),cl_SymbTab);
 			if ((pos == (Symbol *)NULL))
-			  pos=AddVar(Name,&cl_SymbTab,&cl_TabTail);
+			  pos=AddVar(Name_str.c_str(),&cl_SymbTab,&cl_TabTail);
 			if ((pos->NVals == 0))
 			  pos = (Symbol *)NULL;
 		      }
 		    if (pos==NULL)
 		      {
-			pos=AddVar(Name,&cl_SymbTab,&cl_TabTail);
-			SetVar(Name,Val,cl_SymbTab,0,1,cl_do_doinp);
+			// pos=AddVar(Name,&cl_SymbTab,&cl_TabTail);
+			// SetVar(Name,Val,cl_SymbTab,0,1,cl_do_doinp);
+			pos=AddVar(Name_str.c_str(),&cl_SymbTab,&cl_TabTail);
+			SetVar((char*)Name_str.c_str(),(char *)Val_str.c_str(),cl_SymbTab,0,1,cl_do_doinp);
 		      }
-		    if (Name != NULL) {free(Name);Name=NULL;}
-		    if (Val != NULL) {free(Val);Name=NULL;}
+		    // if (Name != NULL) {free(Name);Name=NULL;}
+		    // if (Val != NULL) {free(Val);Name=NULL;}
 		  }
 	      }
 	  }

--- a/code/callbacks.cc
+++ b/code/callbacks.cc
@@ -535,11 +535,8 @@ END{									\
 		  {
 		    std::string Name_str, Val_str;
 		    BreakStrp(line,Name_str,Val_str);
-		    cerr << line << endl;
-		    //		     cerr << "Name:'" << Name_str << "' Val:'" << Val_str << "'" << endl;
 		    stripwhitep(Name_str);
 		    stripwhitep(Val_str);
-		    //		     cerr << "Name:'" << Name_str << "' Val:'" << Val_str << "'" << endl;
 		    pos = NULL;
 
 		    if (Complement)

--- a/code/cl.h
+++ b/code/cl.h
@@ -192,12 +192,14 @@ void      clReset();
 void      clRetry();
 FILE      *clstrtstream_(char *, char *, char *);
 void      stripwhite (char *);
+  void      stripwhitep (std::string& str);
 int       redirect(char *, char *);
 void      yyerror(char *);
 int       clgetConfigFile(char *, char *);
 int       AddCmd(const char *Name, char *Doc, int (*func)(char *), 
 		 CmdSymbol **Head, CmdSymbol **Tail);
 int       BreakStr(char *, char **, char **);
+  int       BreakStrp(const std::string& str, std::string& Name, std::string& Val);
 int       dogo(char *);
 int       dogob(char *);
 int       docd(char *);

--- a/code/support.cc
+++ b/code/support.cc
@@ -114,14 +114,17 @@ extern "C" {
     ----------------------------------------------------------------------*/
   void stripwhitep (std::string& str)
   {
-    auto beg=str.begin(),
-      end=str.end();
-    auto i=beg,j=end;
-    for(i=beg;i != end; i++)
-      if (!std::isspace(*i)) break;
-    for(j=end;j != i;j--)
-      if (!std::isspace(*j)) break;
-    str = std::string(i,j);
+    string tmp(str);
+    auto beg=tmp.begin(),
+      end=tmp.end();
+
+    for(;beg != end; beg++)
+      if (!std::isspace(*beg)) break;
+
+    for(;end != beg;end--)
+      if (!std::isspace(*end)) break;
+
+    str = std::string(beg,end);
   }
 
   void stripwhite (char *string)
@@ -152,9 +155,14 @@ extern "C" {
     for(i=str.begin(); i != str.end(); i++)
       if (*i == '=') break;
     
-    Name = std::string(str.begin(),i);
-    i++;
-    val = std::string(i,str.end());
+    if (str.begin() != i)
+      Name = std::string(str.begin(),i);
+
+    if (i != str.end())
+      {
+	i++;
+	val = std::string(i,str.end());
+      }
     return 1;
   }
   int BreakStr(char *str, char **Name, char **val)

--- a/code/support.cc
+++ b/code/support.cc
@@ -114,16 +114,15 @@ extern "C" {
     ----------------------------------------------------------------------*/
   void stripwhitep (std::string& str)
   {
-    string tmp(str);
-    auto beg=tmp.begin(),
-      end=tmp.end();
+    auto beg=str.begin(),
+      end=str.end()-1;
 
     for(;beg != end; beg++)
-      if (!std::isspace(*beg)) break;
+      if (!std::isspace(static_cast<unsigned char>(*beg))) break;
 
     for(;end != beg;end--)
-      if (!std::isspace(*end)) break;
-
+      if (!std::isspace(static_cast<unsigned char>(*end))) break;
+    end++;
     str = std::string(beg,end);
   }
 

--- a/code/support.cc
+++ b/code/support.cc
@@ -112,6 +112,18 @@ extern "C" {
     Strip any leading white spaces (' ',TAB).  This is useful while 
     reading strings typed by humans.
     ----------------------------------------------------------------------*/
+  void stripwhitep (std::string& str)
+  {
+    auto beg=str.begin(),
+      end=str.end();
+    auto i=beg,j=end;
+    for(i=beg;i != end; i++)
+      if (!std::isspace(*i)) break;
+    for(j=end;j != i;j--)
+      if (!std::isspace(*j)) break;
+    str = std::string(i,j);
+  }
+
   void stripwhite (char *string)
   {
     int i = 0;
@@ -133,6 +145,18 @@ extern "C" {
   /*----------------------------------------------------------------------
     Break a string of the type <Name>=<Value> into Name and Value.
     ----------------------------------------------------------------------*/
+  int BreakStrp(const std::string& str,
+		std::string& Name, std::string& val)
+  {
+    auto i=str.begin();
+    for(i=str.begin(); i != str.end(); i++)
+      if (*i == '=') break;
+    
+    Name = std::string(str.begin(),i);
+    i++;
+    val = std::string(i,str.end());
+    return 1;
+  }
   int BreakStr(char *str, char **Name, char **val)
   {
     char *t,*off;

--- a/code/tstcpp.cc
+++ b/code/tstcpp.cc
@@ -88,6 +88,8 @@ void UI(bool restart, int argc, char **argv)
 
 	i=0;clgetFullValp("fullval",fullVal);
 	i=0;clgetNSValp("strarr",strarr,i);
+	i=0;clgetFullValp("fullval",fullVal);
+	i=0;clgetNSValp("strarr",strarr,i);
 	N=3;N=clgetNValp("farray",fv,N); // Equivalent to clgetNFValp()
       }
       EndCL();


### PR DESCRIPTION
The fix, for now, is to *not* print the `keywords=val(s)` for the app run with the `help=def` option.  On terminals with limited display capabilities (like, it seems to be on some containers -- so much for "containers hide difference in runtime environment"!).

The fix is to not call `doinp("-a")` in the `help==def` section in `ParseCmdLine()` call.  While at it, BreakStrp() and stripwhitep() functions are also added which are C++'ized version of the functions with the same name without the `p` at the end of the name (and, of course, different interface that accepts and returns `std::string`).  These are used in the `doload_and_register()` function, which is called for the `help=def,[file]` commandline option.