### PR TITLE
Hotfix fullval for a bug in clgetFullValp()

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -41,6 +41,7 @@ set(header_list
   clshelldefs.h
   clsh.h
   clstring.h
+  clparseVal.h
   ErrorObj.h
   rl_interface.h
   setAutoDefaults.h

--- a/code/cl.h
+++ b/code/cl.h
@@ -227,7 +227,7 @@ int       dowarranty(char *);
 #ifdef __cplusplus
 int       loadDefaults(int complement=1);
 #endif
-int       clparseVal(Symbol *, int *, double *);
+  //int       clparseVal(Symbol *, int *, double *);
 #ifdef __cplusplus
 void      reportParseError(const Symbol& S, const int& N);
 int       PrintVals(FILE *f,Symbol *S,unsigned int newline=1);

--- a/code/cldbggetBVal.cc
+++ b/code/cldbggetBVal.cc
@@ -21,6 +21,8 @@
 #include <cllib.h>
 #include <shell.h>
 #include <support.h>
+#include <clparseVal.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/code/cldbggetFVal.cc
+++ b/code/cldbggetFVal.cc
@@ -20,6 +20,8 @@
 #include <shell.h>
 #include <cllib.h>
 #include <support.h>
+#include <clparseVal.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/code/cldbggetIVal.cc
+++ b/code/cldbggetIVal.cc
@@ -20,6 +20,7 @@
 #include <cllib.h>
 #include <shell.h>
 #include <support.h>
+#include <clparseVal.h>
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/code/cldbggetNBVal.cc
+++ b/code/cldbggetNBVal.cc
@@ -19,6 +19,7 @@
 /* $Id$ */
 #include <cllib.h>
 #include <sstream>
+#include <clparseVal.h>
 
 #ifdef __cplusplus
 /* extern "C" { */

--- a/code/cldbggetNFVal.cc
+++ b/code/cldbggetNFVal.cc
@@ -19,7 +19,7 @@
 /* $Id: cldbggetNFVal.c,v 2.0 1998/11/11 07:13:00 sanjay Exp $ */
 #include <cllib.h>
 #include <sstream>
-
+#include <clparseVal.h>
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/code/cldbggetNIVal.cc
+++ b/code/cldbggetNIVal.cc
@@ -19,6 +19,7 @@
 /* $Id: cldbggetNIVal.c,v 2.0 1998/11/11 07:13:00 sanjay Exp $ */
 #include <cllib.h>
 #include <sstream>
+#include <clparseVal.h>
 #ifdef __cplusplus
 /* extern "C" { */
 /* #endif */

--- a/code/clgetBaseCode.h
+++ b/code/clgetBaseCode.h
@@ -33,6 +33,7 @@
 #include <shell.h>
 #include <support.h>
 #include <setAutoDefaults.h>
+#include <clparseVal.h>
 #include <type_traits>
 #include <cl.h>
 
@@ -40,8 +41,8 @@ template <class T>
 Symbol* clgetBaseCode(const string& Name, T& val, int& n, SMap &smap=SMap(), bool dbg=false)
 {
   Symbol *S;
-  string type_str="";
-  uint type_int=0;
+  string type_str="Mixed";
+  uint type_int=CL_MIXEDTYPE;
   //
   // Set type string and type integer value based on the type of T
   //

--- a/code/clgetFullVal.cc
+++ b/code/clgetFullVal.cc
@@ -84,7 +84,7 @@ int clgetFullValp(const string& Name, string& val)
 			VString vstr={val};
 			setAutoDefaults<std::string>(S,vstr);//,true);
 
-			val = vecStr2Str(S->Val);
+			//val = vecStr2Str(S->Val);
 		      }
 		    )
 

--- a/code/clgetFullVal.cc
+++ b/code/clgetFullVal.cc
@@ -20,6 +20,7 @@
 #include <cllib.h>
 #include <support.h>
 #include <setAutoDefaults.h>
+#include <clparseVal.h>
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -70,22 +71,38 @@ extern "C" {
 #ifdef __cplusplus
 int clgetFullValp(const string& Name, string& val)
 {
-  int n,i;
   Symbol *S;
 
   HANDLE_EXCEPTIONS(
 		    S=SearchQSymb((char*)Name.c_str(),"Mixed[]");
 		    if (S != NULL)
 		      {
+			SETBIT(S->Attributes,CL_MIXEDTYPE);
 			S->Class=CL_APPLNCLASS;
 			//if (dbg) S->Class=CL_DBGCLASS;
 
 			VString vstr={val};
-			setAutoDefaults<std::string>(S,vstr,true);
+			setAutoDefaults<std::string>(S,vstr);//,true);
 
 			val = vecStr2Str(S->Val);
 		      }
 		    )
+
+    int N = 1;
+    clparseVal(S,&N,val); // The function with val type string does not link.  Don't know why.
+  // if (S!=NULL)
+  //   {
+  //     if (N <= S->NVals)
+  // 	{
+  // 	  val = trim(S->Val[N-1]);
+  // 	  return val.size();
+  // 	}
+  //     else
+  // 	return CL_FAIL;
+  //   }
+
+  return S->Val.size();
+
   // //  setAutoSDefaults(S,val,1);
   // if ((n=clgetNVals((char *)Name.c_str()))>0)
   //   {
@@ -107,6 +124,5 @@ int clgetFullValp(const string& Name, string& val)
   // 	  val = val + tmp;
   // 	}
   //   }
-  return S->Val.size();
 }
 #endif

--- a/code/clgetNBVal.cc
+++ b/code/clgetNBVal.cc
@@ -22,6 +22,7 @@
 #include <support.h>
 #include <sstream>
 #include <clgetBaseCode.h>
+#include <clparseVal.h>
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/code/clhashdefines.h
+++ b/code/clhashdefines.h
@@ -34,6 +34,7 @@
 #define   CL_STRINGTYPE    128
 #define   CL_CMDLINETYPE   256
 #define   CL_BOOLTYPE      512
+#define   CL_MIXEDTYPE     1024
 
 #define   CL_ARG_NONE 1
 #define   CL_ARG_FILENAME 2

--- a/code/clparseVal.cc
+++ b/code/clparseVal.cc
@@ -58,6 +58,8 @@ int clparseVal(Symbol *S, int *Which, string& val)
     return CL_FAIL;
 
 }
+
+
 int clparseVal(Symbol *S, int *Which, double *d)
 {
   unsigned int N = _ABS(*Which),n;

--- a/code/clparseVal.h
+++ b/code/clparseVal.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2000-2021, 2022 S. Bhatnagar (bhatnagar dot sanjay at gmail dot com)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+#ifndef CLPARSEVAL_H
+#define CLPARSEVAL_H
+#include <cl.h>
+
+int clparseVal(Symbol *S, int *Which, double* val);
+int clparseVal(Symbol *S, int *which, string& val);
+#endif

--- a/code/tstcpp.cc
+++ b/code/tstcpp.cc
@@ -30,7 +30,8 @@ void UI(bool restart, int argc, char **argv)
 
   // Set the application to be non-interactive by default.
   // The setting can be changed via the help=prompt keyword.
-  clSetPrompt(false);
+  //  clSetPrompt(false);
+  clSetPrompt(true);
 
   if (!restart)
     {
@@ -41,7 +42,7 @@ void UI(bool restart, int argc, char **argv)
     clRetry();
   try
     {
-      clCmdLineFirst();
+      //clCmdLineFirst();
       {
 	SMap watchPoints; VString exposedKeys;
 	InitMap(watchPoints,exposedKeys);


### PR DESCRIPTION
This fixes a bug due to which default value of unset parameters were not returned correctly via the `clgetFullValp()` calls.  This affects interactive mode, but also the `help=def` mode of usage.

This also includes some code re-factoring and code for enabling optional namespace-style scoping for parameter names.  This is not yet enabled in this PR.